### PR TITLE
Increased Airflow Volume to 32GB

### DIFF
--- a/terraform/modules/services/airflow/eb.tf
+++ b/terraform/modules/services/airflow/eb.tf
@@ -38,7 +38,7 @@ resource "aws_elastic_beanstalk_environment" "eb-api-env" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name = "RootVolumeSize"
-    value = "16"
+    value = "32"
     resource  = ""
   }
 


### PR DESCRIPTION
Increased Airflow Volume to 32GB.
No testing.
Documentation does not mention airflow volume explicitly, therefore no updates to documentation.